### PR TITLE
Update install.mysql.utf8.sql

### DIFF
--- a/admin/sql/install.mysql.utf8.sql
+++ b/admin/sql/install.mysql.utf8.sql
@@ -234,7 +234,7 @@ INSERT IGNORE INTO #__jem_config (`keyname`, `value`) VALUES
 ('showtitle', '1'),
 ('showlocate', '1'),
 ('showcity', '1'),
-('tablewidth', '100%'),
+('tablewidth', ''),
 ('datewidth', '20%'),
 ('datemode', '1'),
 ('titlewidth', '20%'),


### PR DESCRIPTION
for default responsive layout, it's better to leave tablewidth empty
('tablewidth', ''),